### PR TITLE
fix: conventional-pr-name bug

### DIFF
--- a/.github/workflows/conventional-pr-name.yml
+++ b/.github/workflows/conventional-pr-name.yml
@@ -1,4 +1,4 @@
-name: Commitlint
+name: Commitlint PR Title
 on:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']
@@ -8,7 +8,21 @@ jobs:
     name: Validate PR Title (conventional-commit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: npm install @commitlint/config-conventional
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+
+      - name: Get cached dependencies
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn --network-concurrency 1 --frozen-lockfile
+
       - uses: JulienKode/pull-request-name-linter-action@v0.1.2

--- a/docs/changelog/1.0.0-beta.4.md
+++ b/docs/changelog/1.0.0-beta.4.md
@@ -13,3 +13,4 @@
 * [Bug]: Sort By dropdown always displays "Latest", even when using other sort methods [#129](https://github.com/vuestorefront/vendure/issues/129)
 * [Bug]: Filter checkbox cannot be unchecked [#130](https://github.com/vuestorefront/vendure/issues/130)
 * [Bug]: Formatted text not parsed in product page  [#122](https://github.com/vuestorefront/vendure/issues/122)
+* [Bug]: Get rid of the `conventional-pr-name` github action workflow bug 


### PR DESCRIPTION

## Description
Get rid of the conventional-pr-name bug on gh workflow. 
Based on VSF repo changes https://github.com/vuestorefront/vue-storefront/blob/main/.github/workflows/conventional-pr-name.yml 
![Screenshot from 2021-12-10 10-39-42](https://user-images.githubusercontent.com/32042425/145577334-8c5221bb-60a7-4cf9-88bb-6ab0be0011e0.png)


## Related Issue


## Motivation and Context

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
